### PR TITLE
Pinning Latest Dockerfile Content Digest to Parent Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM busybox:latest
+FROM busybox:latest@sha256:7d649ec545c0a0fdfba6f0eb90c0a9277949bfab5c09f723154e2fa60dadfbe6


### PR DESCRIPTION
Updating Parent Docker Image to reference content-digest: `sha256:7d649ec545c0a0fdfba6f0eb90c0a9277949bfab5c09f723154e2fa60dadfbe6`